### PR TITLE
Add initial `github.actions.workflows.name` package

### DIFF
--- a/.github/workflows/conftest.yml
+++ b/.github/workflows/conftest.yml
@@ -1,0 +1,28 @@
+name: Check and validate Conftest Rego policies
+
+'on':
+  push:
+    branches:
+      - main
+  pull_request:
+
+env:
+  CONFTEST_VERSION: "0.36.0"
+
+jobs:
+  conftest:
+    name: Check and validate Conftest Rego policies
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Install conftest
+        run: |
+          mkdir -p "${HOME}/.local/bin"
+          curl -sL "https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz" | tar xzf - -C "${HOME}/.local/bin" conftest
+      - name: Checking Rego formatting style
+        run: |
+          make check-fmt
+      - name: Unit testing conftest policies
+        run: |
+          make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.POSIX:
+
+CONFTEST = conftest
+
+all:
+
+check-fmt:
+	@echo "Checking Rego formatting style"
+	@$(CONFTEST) fmt --check .
+
+fmt:
+	@echo "Formatting Rego files"
+	@$(CONFTEST) fmt .
+
+test:
+	@echo "Unit testing conftest rules"
+	@$(CONFTEST) verify --policy .

--- a/github/actions/workflows/documented_workflow.yml
+++ b/github/actions/workflows/documented_workflow.yml
@@ -1,0 +1,13 @@
+name: This is a documented workflow
+
+jobs:
+  documented:
+    name: This is a documented job
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Nicely documented steps
+        run: echo "Something"
+      - name: Another nicely documented step
+        run: echo "Something else"

--- a/github/actions/workflows/name.rego
+++ b/github/actions/workflows/name.rego
@@ -1,0 +1,38 @@
+# METADATA
+# title: Check `name` keys for workflow, job and steps
+# description: |
+#  GitHub Actions workflows permit to have `name` keys for workflows, jobs and
+#  steps.
+#
+#  The `name` field serves as a short description of workflow/job/step and it
+#  is used in several ways in the UI of GitHub Actions.
+#
+#  Enforcing that is always present make the GitHub Actions workflow more
+#  readable and avoid machine-generated `name` that can be hard to follow.
+# related_resources:
+# - ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
+#   description: Workflow syntax for GitHub Actions
+package github.actions.workflows.name
+
+deny_no_name_in_workflow[msg] {
+	not input.name
+
+	msg := "Workflow should have a `name` key"
+}
+
+deny_no_name_in_job[msg] {
+	input.jobs[job]
+	not input.jobs[job].name
+
+	msg := sprintf("Job `%v` should have a `name` key", [job])
+}
+
+deny_no_name_in_step[msg] {
+	input.jobs[job].steps[step]
+	not input.jobs[job].steps[step].name
+
+	msg := sprintf(
+		"Step `%v` of job `%v` should have a `name` key",
+		[step, job],
+	)
+}

--- a/github/actions/workflows/name_test.rego
+++ b/github/actions/workflows/name_test.rego
@@ -1,0 +1,27 @@
+package github.actions.workflows.name
+
+test_deny_no_name_in_empty_workflow {
+	cfg := parse_config("yaml", "")
+
+	deny_no_name_in_workflow with input as cfg
+}
+
+test_deny_no_name_in_job {
+	cfg := parse_config_file("workflow_with_undocumented_job.yml")
+
+	deny_no_name_in_job with input as cfg
+}
+
+test_deny_no_name_in_step {
+	cfg := parse_config_file("workflow_with_undocumented_step.yml")
+
+	deny_no_name_in_step with input as cfg
+}
+
+test_ok_documented_workflow {
+	cfg := parse_config_file("documented_workflow.yml")
+
+	count(deny_no_name_in_workflow) == 0 with input as cfg
+	count(deny_no_name_in_job) == 0 with input as cfg
+	count(deny_no_name_in_step) == 0 with input as cfg
+}

--- a/github/actions/workflows/workflow_with_undocumented_job.yml
+++ b/github/actions/workflows/workflow_with_undocumented_job.yml
@@ -1,0 +1,14 @@
+name: This is a workflow with a job not documented
+
+jobs:
+  documented:
+    name: This is a documented job
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Documented step in a documented job
+        run: echo "Something"
+  undocumented:
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Documented step in an undocumented job
+        run: echo "Something else"

--- a/github/actions/workflows/workflow_with_undocumented_step.yml
+++ b/github/actions/workflows/workflow_with_undocumented_step.yml
@@ -1,0 +1,10 @@
+name: This is a workflow with a step not documented
+
+jobs:
+  documented:
+    name: This is a documented job
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Documented step in a documented job
+        run: echo "Something"
+      - run: echo "Something else, this step is not documented!"


### PR DESCRIPTION
This PR start to populate the repository with a `github.actions.workflows.name` package that enforces `name` in workflow, step and jobs in GitHub Actions workflows.

It then adds a `Makefile` with some helpful target and reuse them via a GitHub Actions workflow to validate and test policies.
