### PR TITLE
Limit GitHub Actions workflows policies only to GitHub Actions workflows paths

### DIFF
--- a/github/actions/workflows/name.rego
+++ b/github/actions/workflows/name.rego
@@ -14,13 +14,19 @@
 #   description: Workflow syntax for GitHub Actions
 package github.actions.workflows.name
 
+import data.github.actions.workflows.utils as utils
+
 deny_no_name_in_workflow[msg] {
+	f := concat("/", [data.conftest.file.dir, data.conftest.file.name])
+	utils.is_github_workflows(f)
 	not input.name
 
 	msg := "Workflow should have a `name` key"
 }
 
 deny_no_name_in_job[msg] {
+	f := concat("/", [data.conftest.file.dir, data.conftest.file.name])
+	utils.is_github_workflows(f)
 	input.jobs[job]
 	not input.jobs[job].name
 
@@ -28,6 +34,8 @@ deny_no_name_in_job[msg] {
 }
 
 deny_no_name_in_step[msg] {
+	f := concat("/", [data.conftest.file.dir, data.conftest.file.name])
+	utils.is_github_workflows(f)
 	input.jobs[job].steps[step]
 	not input.jobs[job].steps[step].name
 

--- a/github/actions/workflows/utils.rego
+++ b/github/actions/workflows/utils.rego
@@ -1,0 +1,38 @@
+# METADATA
+# title: Utility helpers for github.actions.workflows packages
+# description: |
+#  Utility helpers for github.actions.workflows packages providing common code
+#  for dealing with GitHub Actions workflows.
+# related_resources:
+# - ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
+#   description: Workflow syntax for GitHub Actions
+package github.actions.workflows.utils
+
+import future.keywords.if
+
+# METADATA
+# title: Checks if a string matches GitHub Actions workflows path
+# description: |
+#  `is_github_workflows(s)` checks if the path `s` could be GitHub Actions
+#  workflows path.
+#  
+#  GitHub Actions workflows should be under `.github/workflows` directory and
+#  should ends with `.yml` or `.yaml` file extensions.
+# related_resources:
+# - ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
+#   description: Workflow syntax for GitHub Actions
+is_github_workflows(s) if {
+	glob.match("**/.github/workflows/*.yml", [], s)
+}
+
+is_github_workflows(s) if {
+	glob.match("**/.github/workflows/*.yaml", [], s)
+}
+
+# XXX: Silence the
+# XXX: `? - ... - github.actions.workflows.utils - no policies found'
+# XXX: warning because this package does not contain any policy
+# XXX: otherwise.
+deny if {
+	false
+}

--- a/github/actions/workflows/utils_test.rego
+++ b/github/actions/workflows/utils_test.rego
@@ -1,0 +1,13 @@
+package github.actions.workflows.utils
+
+test_is_github_workflows {
+	is_github_workflows("/some/path/.github/workflows/yes.yml")
+	is_github_workflows("/some/path/.github/workflows/yes.yaml")
+	is_github_workflows("/.github/workflows/yes.yml")
+}
+
+test_is_not_github_workflows {
+	not is_github_workflows("/some/path/.github/other_dir.yml")
+	not is_github_workflows("/some/path/workflows/other_dir.yml")
+	not is_github_workflows("/some/path/.github/workflows/not_yml.txt")
+}


### PR DESCRIPTION
This PR limits the github.actions.workflows.* policies only to file paths that are likely GitHub Actions workflows ones by checking `data.conftest.file.dir` and `data.conftest.file.name`.

Please note that `data.conftest.file.dir` and `data.conftest.file.name` are not always defined and in such cases the policies will be run ignoring that!
