### PR TITLE
Add venom.timeout package

### DIFF
--- a/policy/venom/no_timeout.yml
+++ b/policy/venom/no_timeout.yml
@@ -1,0 +1,17 @@
+name: Test suite with no timeout
+testcases:
+  - name: ok
+    steps:
+      - type: http
+        method: GET
+        timeout: 10
+        url: https://www.example.org/timeout/here/ok
+  - name: not-ok
+    steps:
+      - type: http
+        method: GET
+        timeout: 5
+        url: https://www.example.org/timeout/here/too/ok
+      - type: http
+        method: GET
+        url: https://www.example.org/not/ok

--- a/policy/venom/ok_timeout.yml
+++ b/policy/venom/ok_timeout.yml
@@ -1,0 +1,18 @@
+name: Test suite with all steps with timeouts
+testcases:
+  - name: ok
+    steps:
+      - type: http
+        method: GET
+        timeout: 10
+        url: https://www.example.org/timeout/here/ok
+  - name: ok-too
+    steps:
+      - type: http
+        method: GET
+        timeout: 5
+        url: https://www.example.org/timeout/here/too/ok
+      - type: http
+        method: GET
+        timeout: 1
+        url: https://www.example.org/timeout/here/too/good

--- a/policy/venom/timeout.rego
+++ b/policy/venom/timeout.rego
@@ -1,0 +1,20 @@
+# METADATA
+# title: Enforce `timeout` key for tests
+# description: |
+#  Test steps can hangs indefinitely if they do not define a `timeout`.
+#
+#  Always define a `timeout` in all tests to avoid that.
+# related_resources:
+# - ref: https://cwe.mitre.org/data/definitions/400.html
+#   description: 'CWE-400: Uncontrolled Resource Consumption'
+package venom.timeout
+
+deny_no_timeout[msg] {
+	input.testcases[testcase].steps[step]
+	not input.testcases[testcase].steps[step].timeout
+
+	msg := sprintf(
+		"Test case `%v` of step `%v` should have a `timeout`",
+		[testcase, step],
+	)
+}

--- a/policy/venom/timeout_test.rego
+++ b/policy/venom/timeout_test.rego
@@ -1,0 +1,19 @@
+package venom.timeout
+
+test_ok_no_timeout_in_empty_test {
+	cfg := parse_config("yaml", "")
+
+	count(deny_no_timeout) == 0 with input as cfg
+}
+
+test_deny_no_timeout {
+	cfg := parse_config_file("no_timeout.yml")
+
+	deny_no_timeout with input as cfg
+}
+
+test_ok_all_timeout {
+	cfg := parse_config_file("ok_timeout.yml")
+
+	deny_no_timeout with input as cfg
+}

--- a/policy/venom/timeout_test.yml
+++ b/policy/venom/timeout_test.yml
@@ -1,0 +1,17 @@
+name: Test suite with no timeout
+testcases:
+  - name: ok
+    steps:
+      - type: http
+        method: GET
+        timeout: 10
+        url: https://www.example.org/timeout/here/ok
+  - name: not-ok
+    steps:
+      - type: http
+        method: GET
+        timeout: 5
+        url: https://www.example.org/timeout/here/too/ok
+      - type: http
+        method: GET
+        url: https://www.example.org/not/ok


### PR DESCRIPTION
Add a policy to enforce `timeout` key in all Venom testsuite steps in order to avoid that they can hangs indefinitely.
