### PR TITLE
Warn if a 0 timeout (read "infinite"!) is provided in Venom test suites

### DIFF
--- a/policy/venom/timeout.rego
+++ b/policy/venom/timeout.rego
@@ -4,6 +4,9 @@
 #  Test steps can hangs indefinitely if they do not define a `timeout`.
 #
 #  Always define a `timeout` in all tests to avoid that.
+#
+#  If for some reason this needs to be bypassed, explicitly set `timeout`
+#  to 0.
 # related_resources:
 # - ref: https://cwe.mitre.org/data/definitions/400.html
 #   description: 'CWE-400: Uncontrolled Resource Consumption'
@@ -15,6 +18,15 @@ deny_no_timeout[msg] {
 
 	msg := sprintf(
 		"Test case `%v` of step `%v` should have a `timeout`",
+		[testcase, step],
+	)
+}
+
+warn_zero_timeout[msg] {
+	input.testcases[testcase].steps[step].timeout == 0
+
+	msg := sprintf(
+		"Test case `%v` of step `%v` has an infinite `timeout`",
 		[testcase, step],
 	)
 }

--- a/policy/venom/timeout_test.rego
+++ b/policy/venom/timeout_test.rego
@@ -12,8 +12,9 @@ test_deny_no_timeout {
 	deny_no_timeout with input as cfg
 }
 
-test_ok_all_timeout {
-	cfg := parse_config_file("ok_timeout.yml")
+test_warn_zero_timeout {
+	cfg := parse_config_file("zero_timeout.yml")
 
-	deny_no_timeout with input as cfg
+	count(deny_no_timeout) == 0 with input as cfg
+	warn_zero_timeout with input as cfg
 }

--- a/policy/venom/zero_timeout.yml
+++ b/policy/venom/zero_timeout.yml
@@ -1,0 +1,8 @@
+name: Test suite with an infinite timeout (0)
+testcases:
+  - name: warn-zero
+    steps:
+      - type: http
+        method: GET
+        timeout: 0
+        url: https://www.example.org/hang/forever


### PR DESCRIPTION
Extend `venom.timeout` to warn if a timeout of 0 is provided: internally it is treated as an infinite timeout by Venom.
