### PR TITLE
Add venom.name package

### DIFF
--- a/policy/venom/name.rego
+++ b/policy/venom/name.rego
@@ -1,0 +1,30 @@
+# METADATA
+# title: Check `name` keys for test suite and test cases
+# description: |
+#  Venom permit to have `name` keys for test suite and test cases.
+#
+#  The `name` field serves as a short description of test suite and 
+#  is used in several ways in the report of Venom. For test cases it is used
+#  as an identifier to permit referencing test variables.
+#
+#  Enforcing that is always present make the Venom tests more readable.
+# related_resources:
+# - ref: https://github.com/ovh/venom#concepts
+#   description: 'Venom | Concepts'
+package venom.name
+
+deny_no_name[msg] {
+	# Check explicitly for input.testcases to avoid triggering for user
+	# defined executors
+	input.testcases
+	not input.name
+
+	msg := "Test suite should have a `name` key"
+}
+
+deny_no_name_in_testcase[msg] {
+	input.testcases[testcase]
+	not input.testcases[testcase].name
+
+	msg := sprintf("Test case `%v` should have a `name` key", [testcase])
+}

--- a/policy/venom/name_test.rego
+++ b/policy/venom/name_test.rego
@@ -1,0 +1,20 @@
+package venom.name
+
+test_ok_no_name_in_empty_test {
+	cfg := parse_config("yaml", "")
+
+	count(deny_no_name) == 0 with input as cfg
+	count(deny_no_name_in_testcase) == 0 with input as cfg
+}
+
+test_deny_no_name {
+	cfg := parse_config_file("no_name.yml")
+
+	deny_no_name with input as cfg
+}
+
+test_deny_no_name_in_testcase {
+	cfg := parse_config_file("no_name_testcase.yml")
+
+	deny_no_name_in_testcase with input as cfg
+}

--- a/policy/venom/no_name.yml
+++ b/policy/venom/no_name.yml
@@ -1,0 +1,4 @@
+testcases:
+  - name: no-name
+    steps:
+      - script: echo "Test suite with no name, not ok!"

--- a/policy/venom/no_name_testcase.yml
+++ b/policy/venom/no_name_testcase.yml
@@ -1,0 +1,4 @@
+name: Test suite with a test case with no name
+testcases:
+  - steps:
+      - script: echo "This test case does not have a name, not ok!"


### PR DESCRIPTION
Add a policy to enforce `name` key in all Venom test suites and test cases.

Inspired a lot by `github.actions.workflows.name` package.
