### PR TITLE
Add terraform.aws.aws_iam_policy_attachment package

### DIFF
--- a/policy/terraform/aws/aws_iam_policy_attachment.rego
+++ b/policy/terraform/aws/aws_iam_policy_attachment.rego
@@ -1,0 +1,24 @@
+# METADATA
+# title: Prohibit use of `aws_iam_policy_attachment`
+# description: |
+#  `aws_iam_policy_attachment` creates an exclusive attachment of IAM
+#  policies. If the IAM policy is attached to any other user(s), role(s) and/or
+#  group(s) via another `aws_iam_policy_attachment` the original user(s),
+#  role(s) and/or group(s) will get the attached IAM policy revoked.
+#
+#  `aws_iam_role_policy_attachment`, `aws_iam_user_policy_attachment` and
+#  `aws_iam_group_policy_attachment` can be always used instead and do not have
+#  any exclusive attachment.
+# related_resources:
+# - ref: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy_attachment
+#   description: "`aws_iam_policy_attachment` `hashicorp/aws` provider resource documentation"
+package terraform.aws.aws_iam_policy_attachment
+
+deny_aws_iam_policy_attachment[msg] {
+	input.resource.aws_iam_policy_attachment[resource]
+
+	msg := sprintf(
+		"`aws_iam_policy_attachment` `%v` creates exclusive attachment",
+		[resource],
+	)
+}

--- a/policy/terraform/aws/aws_iam_policy_attachment_test.rego
+++ b/policy/terraform/aws/aws_iam_policy_attachment_test.rego
@@ -1,0 +1,10 @@
+package terraform.aws.aws_iam_policy_attachment
+
+test_deny_aws_iam_policy_attachment {
+	cfg := parse_config(
+		"hcl2",
+		`resource "aws_iam_policy_attachment" "this" {}`,
+	)
+
+	deny_aws_iam_policy_attachment with input as cfg
+}


### PR DESCRIPTION
Add a policy to deny `aws_iam_policy_attachment` usage in Terraform (for `hashicorp/aws` provider).

It is pretty error-prone and it is better to always use `aws_iam_role_policy_attachment`, `aws_iam_user_policy_attachment` and `aws_iam_group_policy_attachment` instead.
