### PR TITLE
Add mdformat GitHub Actions workflow

### DIFF
--- a/.github/workflows/mdformat.yml
+++ b/.github/workflows/mdformat.yml
@@ -1,0 +1,22 @@
+name: Check Markdown formatting via mdformat
+
+'on':
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  mdformat:
+    name: Check Markdown formatting via mdformat
+    runs-on: 'ubuntu-latest'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Install mdformat
+        run: |
+          pip install mdformat
+      - name: Check Markdown formatting via mdformat
+        run: |
+          mdformat --check .


### PR DESCRIPTION
Recursively check Markdown formatting via mdformat.

Unlike other possible linter mdformat has the advantage that can also format the Markdown file too without any manual edit (possible adjustments can be actually needed though for wrapping!).
