### PR TITLE
Check for non-GitHub Actions workflows too

### DIFF
--- a/policy/github/actions/workflows/name_test.rego
+++ b/policy/github/actions/workflows/name_test.rego
@@ -4,12 +4,19 @@ dir := "/some/path/.github/workflows"
 
 name := "test.yml"
 
+notdir := "/some/path/that/is/not/github/workflows"
+
+notname := "test.sh"
+
 test_deny_no_name_in_empty_workflow {
 	cfg := parse_config("yaml", "")
 
 	deny_no_name_in_workflow with input as cfg
 		with data.conftest.file.dir as dir
 		with data.conftest.file.name as name
+	count(deny_no_name_in_workflow) == 0 with input as cfg
+		with data.conftest.file.dir as notdir
+		with data.conftest.file.name as notname
 }
 
 test_deny_no_name_in_job {
@@ -18,6 +25,9 @@ test_deny_no_name_in_job {
 	deny_no_name_in_job with input as cfg
 		with data.conftest.file.dir as dir
 		with data.conftest.file.name as name
+	count(deny_no_name_in_job) == 0 with input as cfg
+		with data.conftest.file.dir as notdir
+		with data.conftest.file.name as notname
 }
 
 test_deny_no_name_in_step {
@@ -26,6 +36,9 @@ test_deny_no_name_in_step {
 	deny_no_name_in_step with input as cfg
 		with data.conftest.file.dir as dir
 		with data.conftest.file.name as name
+	count(deny_no_name_in_step) == 0 with input as cfg
+		with data.conftest.file.dir as notdir
+		with data.conftest.file.name as notname
 }
 
 test_ok_documented_workflow {


### PR DESCRIPTION
Check that all checks that actually trigger deny rules do not trigger any possible false positives if the path is not a GitHub Actions workflows path.
