### PR TITLE
Add github.actions.workflows.setup_version package

### DIFF
--- a/policy/github/actions/workflows/setup_version.rego
+++ b/policy/github/actions/workflows/setup_version.rego
@@ -1,0 +1,78 @@
+# METADATA
+# title: Check that `*-version` in `setup-*` actions is a string
+# description: |
+#  The `*-version` parameters in GitHub Actions workflows `setup-*` should be
+#  a string in order to properly work with versions.
+#
+#  By omitting string in YAML it can fallback to be parsed as a float and
+#  accidentally truncate any possible trailing `0`.
+#
+#  For example, by using `go-version: 1.20` intended to require Go `1.20`
+#  it will be actually parsed as `go-version: 1.2` and Go `1.2` will
+#  be used instead!
+# related_resources:
+# - ref: https://github.com/actions/setup-go
+#   description: GitHub - actions/setup-go
+# - ref: https://github.com/actions/setup-java
+#   description: GitHub - actions/setup-java
+# - ref: https://github.com/actions/setup-node
+#   description: GitHub - actions/setup-node
+# - ref: https://github.com/actions/setup-python
+#   description: GitHub - actions/setup-python
+package github.actions.workflows.setup_version
+
+import future.keywords.in
+
+import data.github.actions.workflows.utils as utils
+
+deny_setup_go_version[msg] {
+	f := concat("/", [data.conftest.file.dir, data.conftest.file.name])
+	utils.is_github_workflows(f)
+	some job, step
+	startswith(input.jobs[job].steps[step].uses, "actions/setup-go")
+	not is_string(input.jobs[job].steps[step]["with"]["go-version"])
+
+	msg := sprintf(
+		"`go-version` in step `%v` of job `%v` that uses `actions/setup-go` should be a string",
+		[step, job],
+	)
+}
+
+deny_setup_java_version[msg] {
+	f := concat("/", [data.conftest.file.dir, data.conftest.file.name])
+	utils.is_github_workflows(f)
+	some job, step
+	startswith(input.jobs[job].steps[step].uses, "actions/setup-java")
+	not is_string(input.jobs[job].steps[step]["with"]["java-version"])
+
+	msg := sprintf(
+		"`java-version` in step `%v` of job `%v` that uses `actions/setup-java` should be a string",
+		[step, job],
+	)
+}
+
+deny_setup_node_version[msg] {
+	f := concat("/", [data.conftest.file.dir, data.conftest.file.name])
+	utils.is_github_workflows(f)
+	some job, step
+	startswith(input.jobs[job].steps[step].uses, "actions/setup-node")
+	not is_string(input.jobs[job].steps[step]["with"]["node-version"])
+
+	msg := sprintf(
+		"`node-version` in step `%v` of job `%v` that uses `actions/setup-node` should be a string",
+		[step, job],
+	)
+}
+
+deny_setup_python_version[msg] {
+	f := concat("/", [data.conftest.file.dir, data.conftest.file.name])
+	utils.is_github_workflows(f)
+	some job, step
+	startswith(input.jobs[job].steps[step].uses, "actions/setup-python")
+	not is_string(input.jobs[job].steps[step]["with"]["python-version"])
+
+	msg := sprintf(
+		"`python-version` in step `%v` of job `%v` that uses `actions/setup-python` should be a string",
+		[step, job],
+	)
+}

--- a/policy/github/actions/workflows/setup_version_go_with_go_version_float.yml
+++ b/policy/github/actions/workflows/setup_version_go_with_go_version_float.yml
@@ -1,0 +1,8 @@
+name: Testing setup-go (using setup-go with a float)
+
+jobs:
+  build:
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.20

--- a/policy/github/actions/workflows/setup_version_go_with_go_version_string.yml
+++ b/policy/github/actions/workflows/setup_version_go_with_go_version_string.yml
@@ -1,0 +1,8 @@
+name: Testing setup-go (using setup-go with a string)
+
+jobs:
+  build:
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.20'

--- a/policy/github/actions/workflows/setup_version_go_without_go_version.yml
+++ b/policy/github/actions/workflows/setup_version_go_without_go_version.yml
@@ -1,0 +1,6 @@
+name: Testing setup-go (using setup-go without any with)
+
+jobs:
+  build:
+    steps:
+      - uses: actions/setup-go@v3

--- a/policy/github/actions/workflows/setup_version_java_with_java_version_float.yml
+++ b/policy/github/actions/workflows/setup_version_java_with_java_version_float.yml
@@ -1,0 +1,9 @@
+name: Testing setup-java (using setup-java with a float)
+
+jobs:
+  build:
+    steps:
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: 17.0

--- a/policy/github/actions/workflows/setup_version_java_with_java_version_string.yml
+++ b/policy/github/actions/workflows/setup_version_java_with_java_version_string.yml
@@ -1,0 +1,9 @@
+name: Testing setup-java (using setup-java with a string)
+
+jobs:
+  build:
+    steps:
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17.0'

--- a/policy/github/actions/workflows/setup_version_java_without_java_version.yml
+++ b/policy/github/actions/workflows/setup_version_java_without_java_version.yml
@@ -1,0 +1,6 @@
+name: Testing setup-java (using setup-java without any with)
+
+jobs:
+  build:
+    steps:
+      - uses: actions/setup-java@v3

--- a/policy/github/actions/workflows/setup_version_node_with_node_version_float.yml
+++ b/policy/github/actions/workflows/setup_version_node_with_node_version_float.yml
@@ -1,0 +1,8 @@
+name: Testing setup-node (using setup-node with a float)
+
+jobs:
+  build:
+    steps:
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16.15

--- a/policy/github/actions/workflows/setup_version_node_with_node_version_string.yml
+++ b/policy/github/actions/workflows/setup_version_node_with_node_version_string.yml
@@ -1,0 +1,8 @@
+name: Testing setup-node (using setup-node with a string)
+
+jobs:
+  build:
+    steps:
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16.15'

--- a/policy/github/actions/workflows/setup_version_node_without_node_version.yml
+++ b/policy/github/actions/workflows/setup_version_node_without_node_version.yml
@@ -1,0 +1,6 @@
+name: Testing setup-node (using setup-node without any with)
+
+jobs:
+  build:
+    steps:
+      - uses: actions/setup-node@v3

--- a/policy/github/actions/workflows/setup_version_python_with_python_version_float.yml
+++ b/policy/github/actions/workflows/setup_version_python_with_python_version_float.yml
@@ -1,0 +1,8 @@
+name: Testing setup-python (using setup-python with a float)
+
+jobs:
+  build:
+    steps:
+      - uses: actions/setup-python@v3
+        with:
+          python-version: 3.10

--- a/policy/github/actions/workflows/setup_version_python_with_python_version_string.yml
+++ b/policy/github/actions/workflows/setup_version_python_with_python_version_string.yml
@@ -1,0 +1,8 @@
+name: Testing setup-python (using setup-python with a string)
+
+jobs:
+  build:
+    steps:
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.10'

--- a/policy/github/actions/workflows/setup_version_python_without_python_version.yml
+++ b/policy/github/actions/workflows/setup_version_python_without_python_version.yml
@@ -1,0 +1,6 @@
+name: Testing setup-python (using setup-python without any with)
+
+jobs:
+  build:
+    steps:
+      - uses: actions/setup-python@v3

--- a/policy/github/actions/workflows/setup_version_test.rego
+++ b/policy/github/actions/workflows/setup_version_test.rego
@@ -1,0 +1,101 @@
+package github.actions.workflows.setup_version
+
+dir := "/some/path/.github/workflows"
+
+name := "test.yml"
+
+test_deny_setup_go_version_float {
+	cfg := parse_config_file("setup_version_go_with_go_version_float.yml")
+
+	deny_setup_go_version with input as cfg
+		with data.conftest.file.dir as dir
+		with data.conftest.file.name as name
+}
+
+test_ok_setup_go_without_go_version {
+	cfg := parse_config_file("setup_version_go_without_go_version.yml")
+
+	count(deny_setup_go_version) == 0 with input as cfg
+		with data.conftest.file.dir as dir
+		with data.conftest.file.name as name
+}
+
+test_ok_setup_go_with_string {
+	cfg := parse_config_file("setup_version_go_with_go_version_string.yml")
+
+	count(deny_setup_go_version) == 0 with input as cfg
+		with data.conftest.file.dir as dir
+		with data.conftest.file.name as name
+}
+
+test_deny_setup_java_version_float {
+	cfg := parse_config_file("setup_version_java_with_java_version_float.yml")
+
+	deny_setup_java_version with input as cfg
+		with data.conftest.file.dir as dir
+		with data.conftest.file.name as name
+}
+
+test_ok_setup_java_without_java_version {
+	cfg := parse_config_file("setup_version_java_without_java_version.yml")
+
+	count(deny_setup_java_version) == 0 with input as cfg
+		with data.conftest.file.dir as dir
+		with data.conftest.file.name as name
+}
+
+test_ok_setup_java_with_string {
+	cfg := parse_config_file("setup_version_java_with_java_version_string.yml")
+
+	count(deny_setup_java_version) == 0 with input as cfg
+		with data.conftest.file.dir as dir
+		with data.conftest.file.name as name
+}
+
+test_deny_setup_node_version_float {
+	cfg := parse_config_file("setup_version_node_with_node_version_float.yml")
+
+	deny_setup_node_version with input as cfg
+		with data.conftest.file.dir as dir
+		with data.conftest.file.name as name
+}
+
+test_ok_setup_node_without_node_version {
+	cfg := parse_config_file("setup_version_node_without_node_version.yml")
+
+	count(deny_setup_node_version) == 0 with input as cfg
+		with data.conftest.file.dir as dir
+		with data.conftest.file.name as name
+}
+
+test_ok_setup_node_with_string {
+	cfg := parse_config_file("setup_version_node_with_node_version_string.yml")
+
+	count(deny_setup_node_version) == 0 with input as cfg
+		with data.conftest.file.dir as dir
+		with data.conftest.file.name as name
+}
+
+test_deny_setup_python_version_float {
+	cfg := parse_config_file("setup_version_python_with_python_version_float.yml")
+
+	deny_setup_python_version with input as cfg
+		with data.conftest.file.dir as dir
+		with data.conftest.file.name as name
+}
+
+test_ok_setup_python_without_python_version {
+	cfg := parse_config_file("setup_version_python_without_python_version.yml")
+
+	count(deny_setup_python_version) == 0 with input as cfg
+		with data.conftest.file.dir as dir
+		with data.conftest.file.name as name
+}
+
+test_ok_setup_python_with_string {
+	cfg := parse_config_file("setup_version_python_with_python_version_string.yml")
+
+	count(deny_setup_python_version) == 0 with input as cfg
+		with data.conftest.file.dir as dir
+		with data.conftest.file.name as name
+}


### PR DESCRIPTION
Check that `*-version` in the `setup-*` actions are strings.

When using the various `setup-*` actions due YAML can truncate possible trailing 0-s ending up using Go 1.2 (instead of Go 1.20) or Python 3.1 (instead of Python 3.10).

In some cases this is not easy to debug.

Add conftest rules to spot such cases.
