### PR TITLE
Add github.dependabot.* packages

### DIFF
--- a/policy/github/dependabot/dependabot.yml
+++ b/policy/github/dependabot/dependabot.yml
@@ -1,0 +1,12 @@
+# Test, simple and correct Dependabot configuration file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/policy/github/dependabot/mandatory_toplevel_keys.rego
+++ b/policy/github/dependabot/mandatory_toplevel_keys.rego
@@ -1,0 +1,37 @@
+# METADATA
+# title: Check mandatory top-level keys
+# description: |
+#  All dependabot.yml files should have `version` and `updates` top-level
+#  keys.
+# related_resources:
+# - ref: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#   description: Configuration options for the dependabot.yml file
+package github.dependabot.mandatory_toplevel_keys
+
+import future.keywords.in
+
+import data.github.dependabot.utils
+
+deny_no_updates[msg] {
+	f := concat("/", [data.conftest.file.dir, data.conftest.file.name])
+	utils.is_github_dependabot(f)
+	not input.updates
+
+	msg := "`dependabot.yml` should have an `updates` top-level key"
+}
+
+deny_no_version[msg] {
+	f := concat("/", [data.conftest.file.dir, data.conftest.file.name])
+	utils.is_github_dependabot(f)
+	not input.version
+
+	msg := "`dependabot.yml` should have `version` top-level key"
+}
+
+deny_incorrect_version[msg] {
+	f := concat("/", [data.conftest.file.dir, data.conftest.file.name])
+	utils.is_github_dependabot(f)
+	not input.version == 2
+
+	msg := "`dependabot.yml` `version` should be 2"
+}

--- a/policy/github/dependabot/mandatory_toplevel_keys_test.rego
+++ b/policy/github/dependabot/mandatory_toplevel_keys_test.rego
@@ -1,0 +1,45 @@
+package github.dependabot.mandatory_toplevel_keys
+
+dir := "/some/path/.github"
+
+name := "dependabot.yml"
+
+notdir := "/some/path/that/is/not/github"
+
+notname := "not-dependabot.yml"
+
+test_deny_no_updates_in_empty_dependabot {
+	cfg := parse_config("yaml", "")
+
+	deny_no_updates with input as cfg
+		with data.conftest.file.dir as dir
+		with data.conftest.file.name as name
+	count(deny_no_updates) == 0 with input as cfg
+		with data.conftest.file.dir as notdir
+		with data.conftest.file.name as notname
+}
+
+test_deny_no_version_in_empty_dependabot {
+	cfg := parse_config("yaml", "")
+
+	deny_no_version with input as cfg
+		with data.conftest.file.dir as dir
+		with data.conftest.file.name as name
+	count(deny_no_version) == 0 with input as cfg
+		with data.conftest.file.dir as notdir
+		with data.conftest.file.name as notname
+}
+
+test_ok_dependabot {
+	cfg := parse_config_file("dependabot.yml")
+
+	count(deny_no_updates) == 0 with input as cfg
+		with data.conftest.file.dir as dir
+		with data.conftest.file.name as name
+	count(deny_no_version) == 0 with input as cfg
+		with data.conftest.file.dir as dir
+		with data.conftest.file.name as name
+	count(deny_incorrect_version) == 0 with input as cfg
+		with data.conftest.file.dir as dir
+		with data.conftest.file.name as name
+}

--- a/policy/github/dependabot/utils.rego
+++ b/policy/github/dependabot/utils.rego
@@ -1,0 +1,33 @@
+# METADATA
+# title: Utility helpers for github.dependabot packages
+# description: |
+#  Utility helpers for github.dependabot packages providing common code
+#  for dealing with GitHub `dependabot.yml` file.
+# related_resources:
+# - ref: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#   description: Configuration options for the dependabot.yml file
+package github.dependabot.utils
+
+import future.keywords.if
+
+# METADATA
+# title: Checks if a string matches GitHub `dependabot.yml` path
+# description: |
+#  `is_github_dependabot(s)` checks if the path `s` could be GitHub
+#  `dependabot.yml` path.
+#  
+#  GitHub `dependabot.yml` should be under `.github` directory.
+# related_resources:
+# - ref: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#   description: Configuration options for the dependabot.yml file
+is_github_dependabot(s) if {
+	glob.match("**/.github/dependabot.yml", [], s)
+}
+
+# XXX: Silence the
+# XXX: `? - ... - github.dependabot.utils - no policies found'
+# XXX: warning because this package does not contain any policy
+# XXX: otherwise.
+deny if {
+	false
+}

--- a/policy/github/dependabot/utils_test.rego
+++ b/policy/github/dependabot/utils_test.rego
@@ -1,0 +1,12 @@
+package github.dependabot.utils
+
+test_is_github_dependabot {
+	is_github_dependabot("/some/path/.github/dependabot.yml")
+	is_github_dependabot("/.github/dependabot.yml")
+}
+
+test_is_not_github_dependabot {
+	not is_github_dependabot("/some/path/.github/workflows/dependabot.yml")
+	not is_github_dependabot("/some/path/dependabot.yml")
+	not is_github_dependabot("/some/path/.github/dependabot.yaml")
+}


### PR DESCRIPTION
Add packages intended to be used to check GitHub Dependabot `dependabot.yml` files.

`mandatory_toplevel_keys` package ensure that it passes minimum syntactic checks regarding needed top-level keys.
