### PR TITLE
Do not test outside test packages

### DIFF
--- a/policy/github/actions/workflows/name_test.rego
+++ b/policy/github/actions/workflows/name_test.rego
@@ -1,4 +1,6 @@
-package github.actions.workflows.name
+package github.actions.workflows.name_test
+
+import data.github.actions.workflows.name
 
 dir := "/some/path/.github/workflows"
 
@@ -11,10 +13,10 @@ notname := "test.sh"
 test_deny_no_name_in_empty_workflow {
 	cfg := parse_config("yaml", "")
 
-	deny_no_name_in_workflow with input as cfg
+	name.deny_no_name_in_workflow with input as cfg
 		with data.conftest.file.dir as dir
 		with data.conftest.file.name as name
-	count(deny_no_name_in_workflow) == 0 with input as cfg
+	count(name.deny_no_name_in_workflow) == 0 with input as cfg
 		with data.conftest.file.dir as notdir
 		with data.conftest.file.name as notname
 }
@@ -22,10 +24,10 @@ test_deny_no_name_in_empty_workflow {
 test_deny_no_name_in_job {
 	cfg := parse_config_file("workflow_with_undocumented_job.yml")
 
-	deny_no_name_in_job with input as cfg
+	name.deny_no_name_in_job with input as cfg
 		with data.conftest.file.dir as dir
 		with data.conftest.file.name as name
-	count(deny_no_name_in_job) == 0 with input as cfg
+	count(name.deny_no_name_in_job) == 0 with input as cfg
 		with data.conftest.file.dir as notdir
 		with data.conftest.file.name as notname
 }
@@ -33,10 +35,10 @@ test_deny_no_name_in_job {
 test_deny_no_name_in_step {
 	cfg := parse_config_file("workflow_with_undocumented_step.yml")
 
-	deny_no_name_in_step with input as cfg
+	name.deny_no_name_in_step with input as cfg
 		with data.conftest.file.dir as dir
 		with data.conftest.file.name as name
-	count(deny_no_name_in_step) == 0 with input as cfg
+	count(name.deny_no_name_in_step) == 0 with input as cfg
 		with data.conftest.file.dir as notdir
 		with data.conftest.file.name as notname
 }
@@ -44,13 +46,13 @@ test_deny_no_name_in_step {
 test_ok_documented_workflow {
 	cfg := parse_config_file("documented_workflow.yml")
 
-	count(deny_no_name_in_workflow) == 0 with input as cfg
+	count(name.deny_no_name_in_workflow) == 0 with input as cfg
 		with data.conftest.file.dir as dir
 		with data.conftest.file.name as name
-	count(deny_no_name_in_job) == 0 with input as cfg
+	count(name.deny_no_name_in_job) == 0 with input as cfg
 		with data.conftest.file.dir as dir
 		with data.conftest.file.name as name
-	count(deny_no_name_in_step) == 0 with input as cfg
+	count(name.deny_no_name_in_step) == 0 with input as cfg
 		with data.conftest.file.dir as dir
 		with data.conftest.file.name as name
 }

--- a/policy/github/actions/workflows/setup_version_test.rego
+++ b/policy/github/actions/workflows/setup_version_test.rego
@@ -1,4 +1,6 @@
-package github.actions.workflows.setup_version
+package github.actions.workflows.setup_version_test
+
+import data.github.actions.workflows.setup_version
 
 dir := "/some/path/.github/workflows"
 
@@ -7,7 +9,7 @@ name := "test.yml"
 test_deny_setup_go_version_float {
 	cfg := parse_config_file("setup_version_go_with_go_version_float.yml")
 
-	deny_setup_go_version with input as cfg
+	setup_version.deny_setup_go_version with input as cfg
 		with data.conftest.file.dir as dir
 		with data.conftest.file.name as name
 }
@@ -15,7 +17,7 @@ test_deny_setup_go_version_float {
 test_ok_setup_go_without_go_version {
 	cfg := parse_config_file("setup_version_go_without_go_version.yml")
 
-	count(deny_setup_go_version) == 0 with input as cfg
+	count(setup_version.deny_setup_go_version) == 0 with input as cfg
 		with data.conftest.file.dir as dir
 		with data.conftest.file.name as name
 }
@@ -23,7 +25,7 @@ test_ok_setup_go_without_go_version {
 test_ok_setup_go_with_string {
 	cfg := parse_config_file("setup_version_go_with_go_version_string.yml")
 
-	count(deny_setup_go_version) == 0 with input as cfg
+	count(setup_version.deny_setup_go_version) == 0 with input as cfg
 		with data.conftest.file.dir as dir
 		with data.conftest.file.name as name
 }
@@ -31,7 +33,7 @@ test_ok_setup_go_with_string {
 test_deny_setup_java_version_float {
 	cfg := parse_config_file("setup_version_java_with_java_version_float.yml")
 
-	deny_setup_java_version with input as cfg
+	setup_version.deny_setup_java_version with input as cfg
 		with data.conftest.file.dir as dir
 		with data.conftest.file.name as name
 }
@@ -39,7 +41,7 @@ test_deny_setup_java_version_float {
 test_ok_setup_java_without_java_version {
 	cfg := parse_config_file("setup_version_java_without_java_version.yml")
 
-	count(deny_setup_java_version) == 0 with input as cfg
+	count(setup_version.deny_setup_java_version) == 0 with input as cfg
 		with data.conftest.file.dir as dir
 		with data.conftest.file.name as name
 }
@@ -47,7 +49,7 @@ test_ok_setup_java_without_java_version {
 test_ok_setup_java_with_string {
 	cfg := parse_config_file("setup_version_java_with_java_version_string.yml")
 
-	count(deny_setup_java_version) == 0 with input as cfg
+	count(setup_version.deny_setup_java_version) == 0 with input as cfg
 		with data.conftest.file.dir as dir
 		with data.conftest.file.name as name
 }
@@ -55,7 +57,7 @@ test_ok_setup_java_with_string {
 test_deny_setup_node_version_float {
 	cfg := parse_config_file("setup_version_node_with_node_version_float.yml")
 
-	deny_setup_node_version with input as cfg
+	setup_version.deny_setup_node_version with input as cfg
 		with data.conftest.file.dir as dir
 		with data.conftest.file.name as name
 }
@@ -63,7 +65,7 @@ test_deny_setup_node_version_float {
 test_ok_setup_node_without_node_version {
 	cfg := parse_config_file("setup_version_node_without_node_version.yml")
 
-	count(deny_setup_node_version) == 0 with input as cfg
+	count(setup_version.deny_setup_node_version) == 0 with input as cfg
 		with data.conftest.file.dir as dir
 		with data.conftest.file.name as name
 }
@@ -71,7 +73,7 @@ test_ok_setup_node_without_node_version {
 test_ok_setup_node_with_string {
 	cfg := parse_config_file("setup_version_node_with_node_version_string.yml")
 
-	count(deny_setup_node_version) == 0 with input as cfg
+	count(setup_version.deny_setup_node_version) == 0 with input as cfg
 		with data.conftest.file.dir as dir
 		with data.conftest.file.name as name
 }
@@ -79,7 +81,7 @@ test_ok_setup_node_with_string {
 test_deny_setup_python_version_float {
 	cfg := parse_config_file("setup_version_python_with_python_version_float.yml")
 
-	deny_setup_python_version with input as cfg
+	setup_version.deny_setup_python_version with input as cfg
 		with data.conftest.file.dir as dir
 		with data.conftest.file.name as name
 }
@@ -87,7 +89,7 @@ test_deny_setup_python_version_float {
 test_ok_setup_python_without_python_version {
 	cfg := parse_config_file("setup_version_python_without_python_version.yml")
 
-	count(deny_setup_python_version) == 0 with input as cfg
+	count(setup_version.deny_setup_python_version) == 0 with input as cfg
 		with data.conftest.file.dir as dir
 		with data.conftest.file.name as name
 }
@@ -95,7 +97,7 @@ test_ok_setup_python_without_python_version {
 test_ok_setup_python_with_string {
 	cfg := parse_config_file("setup_version_python_with_python_version_string.yml")
 
-	count(deny_setup_python_version) == 0 with input as cfg
+	count(setup_version.deny_setup_python_version) == 0 with input as cfg
 		with data.conftest.file.dir as dir
 		with data.conftest.file.name as name
 }

--- a/policy/github/actions/workflows/utils_test.rego
+++ b/policy/github/actions/workflows/utils_test.rego
@@ -1,13 +1,15 @@
-package github.actions.workflows.utils
+package github.actions.workflows.utils_test
+
+import data.github.actions.workflows.utils
 
 test_is_github_workflows {
-	is_github_workflows("/some/path/.github/workflows/yes.yml")
-	is_github_workflows("/some/path/.github/workflows/yes.yaml")
-	is_github_workflows("/.github/workflows/yes.yml")
+	utils.is_github_workflows("/some/path/.github/workflows/yes.yml")
+	utils.is_github_workflows("/some/path/.github/workflows/yes.yaml")
+	utils.is_github_workflows("/.github/workflows/yes.yml")
 }
 
 test_is_not_github_workflows {
-	not is_github_workflows("/some/path/.github/other_dir.yml")
-	not is_github_workflows("/some/path/workflows/other_dir.yml")
-	not is_github_workflows("/some/path/.github/workflows/not_yml.txt")
+	not utils.is_github_workflows("/some/path/.github/other_dir.yml")
+	not utils.is_github_workflows("/some/path/workflows/other_dir.yml")
+	not utils.is_github_workflows("/some/path/.github/workflows/not_yml.txt")
 }

--- a/policy/github/dependabot/mandatory_toplevel_keys_test.rego
+++ b/policy/github/dependabot/mandatory_toplevel_keys_test.rego
@@ -1,4 +1,6 @@
-package github.dependabot.mandatory_toplevel_keys
+package github.dependabot.mandatory_toplevel_keys_test
+
+import data.github.dependabot.mandatory_toplevel_keys
 
 dir := "/some/path/.github"
 
@@ -11,10 +13,10 @@ notname := "not-dependabot.yml"
 test_deny_no_updates_in_empty_dependabot {
 	cfg := parse_config("yaml", "")
 
-	deny_no_updates with input as cfg
+	mandatory_toplevel_keys.deny_no_updates with input as cfg
 		with data.conftest.file.dir as dir
 		with data.conftest.file.name as name
-	count(deny_no_updates) == 0 with input as cfg
+	count(mandatory_toplevel_keys.deny_no_updates) == 0 with input as cfg
 		with data.conftest.file.dir as notdir
 		with data.conftest.file.name as notname
 }
@@ -22,10 +24,10 @@ test_deny_no_updates_in_empty_dependabot {
 test_deny_no_version_in_empty_dependabot {
 	cfg := parse_config("yaml", "")
 
-	deny_no_version with input as cfg
+	mandatory_toplevel_keys.deny_no_version with input as cfg
 		with data.conftest.file.dir as dir
 		with data.conftest.file.name as name
-	count(deny_no_version) == 0 with input as cfg
+	count(mandatory_toplevel_keys.deny_no_version) == 0 with input as cfg
 		with data.conftest.file.dir as notdir
 		with data.conftest.file.name as notname
 }
@@ -33,13 +35,13 @@ test_deny_no_version_in_empty_dependabot {
 test_ok_dependabot {
 	cfg := parse_config_file("dependabot.yml")
 
-	count(deny_no_updates) == 0 with input as cfg
+	count(mandatory_toplevel_keys.deny_no_updates) == 0 with input as cfg
 		with data.conftest.file.dir as dir
 		with data.conftest.file.name as name
-	count(deny_no_version) == 0 with input as cfg
+	count(mandatory_toplevel_keys.deny_no_version) == 0 with input as cfg
 		with data.conftest.file.dir as dir
 		with data.conftest.file.name as name
-	count(deny_incorrect_version) == 0 with input as cfg
+	count(mandatory_toplevel_keys.deny_incorrect_version) == 0 with input as cfg
 		with data.conftest.file.dir as dir
 		with data.conftest.file.name as name
 }

--- a/policy/github/dependabot/utils_test.rego
+++ b/policy/github/dependabot/utils_test.rego
@@ -1,12 +1,14 @@
-package github.dependabot.utils
+package github.dependabot.utils_test
+
+import data.github.dependabot.utils
 
 test_is_github_dependabot {
-	is_github_dependabot("/some/path/.github/dependabot.yml")
-	is_github_dependabot("/.github/dependabot.yml")
+	utils.is_github_dependabot("/some/path/.github/dependabot.yml")
+	utils.is_github_dependabot("/.github/dependabot.yml")
 }
 
 test_is_not_github_dependabot {
-	not is_github_dependabot("/some/path/.github/workflows/dependabot.yml")
-	not is_github_dependabot("/some/path/dependabot.yml")
-	not is_github_dependabot("/some/path/.github/dependabot.yaml")
+	not utils.is_github_dependabot("/some/path/.github/workflows/dependabot.yml")
+	not utils.is_github_dependabot("/some/path/dependabot.yml")
+	not utils.is_github_dependabot("/some/path/.github/dependabot.yaml")
 }

--- a/policy/terraform/aws/aws_iam_policy_attachment_test.rego
+++ b/policy/terraform/aws/aws_iam_policy_attachment_test.rego
@@ -1,4 +1,6 @@
-package terraform.aws.aws_iam_policy_attachment
+package terraform.aws.aws_iam_policy_attachment_test
+
+import data.terraform.aws.aws_iam_policy_attachment
 
 test_deny_aws_iam_policy_attachment {
 	cfg := parse_config(
@@ -6,5 +8,5 @@ test_deny_aws_iam_policy_attachment {
 		`resource "aws_iam_policy_attachment" "this" {}`,
 	)
 
-	deny_aws_iam_policy_attachment with input as cfg
+	aws_iam_policy_attachment.deny_aws_iam_policy_attachment with input as cfg
 }

--- a/policy/venom/name_test.rego
+++ b/policy/venom/name_test.rego
@@ -1,26 +1,28 @@
-package venom.name
+package venom.name_test
+
+import data.venom.name
 
 test_ok_no_name_in_empty_test {
 	cfg := parse_config("yaml", "")
 
-	count(deny_no_name) == 0 with input as cfg
-	count(deny_no_name_in_testcase) == 0 with input as cfg
+	count(name.deny_no_name) == 0 with input as cfg
+	count(name.deny_no_name_in_testcase) == 0 with input as cfg
 }
 
 test_deny_no_name {
 	cfg := parse_config_file("no_name.yml")
 
-	deny_no_name with input as cfg
+	name.deny_no_name with input as cfg
 }
 
 test_deny_no_name_in_testcase {
 	cfg := parse_config_file("no_name_testcase.yml")
 
-	deny_no_name_in_testcase with input as cfg
+	name.deny_no_name_in_testcase with input as cfg
 }
 
 test_deny_no_name_in_step {
 	cfg := parse_config_file("no_name_step.yml")
 
-	deny_no_name_in_step with input as cfg
+	name.deny_no_name_in_step with input as cfg
 }

--- a/policy/venom/timeout_test.rego
+++ b/policy/venom/timeout_test.rego
@@ -1,20 +1,22 @@
-package venom.timeout
+package venom.timeout_test
+
+import data.venom.timeout
 
 test_ok_no_timeout_in_empty_test {
 	cfg := parse_config("yaml", "")
 
-	count(deny_no_timeout) == 0 with input as cfg
+	count(timeout.deny_no_timeout) == 0 with input as cfg
 }
 
 test_deny_no_timeout {
 	cfg := parse_config_file("no_timeout.yml")
 
-	deny_no_timeout with input as cfg
+	timeout.deny_no_timeout with input as cfg
 }
 
 test_warn_zero_timeout {
 	cfg := parse_config_file("zero_timeout.yml")
 
-	count(deny_no_timeout) == 0 with input as cfg
-	warn_zero_timeout with input as cfg
+	count(timeout.deny_no_timeout) == 0 with input as cfg
+	timeout.warn_zero_timeout with input as cfg
 }


### PR DESCRIPTION
Mechanically avoid the [test-outside-test-package-fix](https://docs.styra.com/regal/rules/testing/test-outside-test-package) Regal violation by using <https://gist.github.com/iamleot/2017b3c27ddb44572c32ea90630dfcee> to adjust all such uses.

Script applied as is except for manually adjusting:

- `policy/github/actions/workflows/utils_test.rego`
- `policy/github/dependabot/utils_test.rego`

...that had custom rules not matching `deny|warning|violation` RE pattern.
