### PR TITLE
Revert "Address all Regal prefer-some-in-iteration violations"

### DIFF
--- a/policy/github/actions/workflows/name.rego
+++ b/policy/github/actions/workflows/name.rego
@@ -29,7 +29,8 @@ deny_no_name_in_workflow[msg] {
 deny_no_name_in_job[msg] {
 	f := concat("/", [data.conftest.file.dir, data.conftest.file.name])
 	utils.is_github_workflows(f)
-	some job in input.jobs
+	some job
+	input.jobs[job]
 	not input.jobs[job].name
 
 	msg := sprintf("Job `%v` should have a `name` key", [job])
@@ -38,8 +39,8 @@ deny_no_name_in_job[msg] {
 deny_no_name_in_step[msg] {
 	f := concat("/", [data.conftest.file.dir, data.conftest.file.name])
 	utils.is_github_workflows(f)
-	some job in input.jobs
-	some step in input.jobs[job].steps
+	some job, step
+	input.jobs[job].steps[step]
 	not input.jobs[job].steps[step].name
 
 	msg := sprintf(

--- a/policy/terraform/aws/aws_iam_policy_attachment.rego
+++ b/policy/terraform/aws/aws_iam_policy_attachment.rego
@@ -17,7 +17,8 @@ package terraform.aws.aws_iam_policy_attachment
 import future.keywords.in
 
 deny_aws_iam_policy_attachment[msg] {
-	some resource in input.resource.aws_iam_policy_attachment
+	some resource
+	input.resource.aws_iam_policy_attachment[resource]
 
 	msg := sprintf(
 		"`aws_iam_policy_attachment` `%v` creates exclusive attachment",

--- a/policy/venom/name.rego
+++ b/policy/venom/name.rego
@@ -25,15 +25,16 @@ deny_no_name[msg] {
 }
 
 deny_no_name_in_testcase[msg] {
-	some testcase in input.testcases
+	some testcase
+	input.testcases[testcase]
 	not input.testcases[testcase].name
 
 	msg := sprintf("Test case `%v` should have a `name` key", [testcase])
 }
 
 deny_no_name_in_step[msg] {
-	some testcase in input.testcases
-	some step in input.testcases[testcase].steps
+	some testcase, step
+	input.testcases[testcase].steps[step]
 	not input.testcases[testcase].steps[step].name
 
 	msg := sprintf(


### PR DESCRIPTION
Reverts commit 35314ce23f7676b95fae18f73f9577aff2f0da03 because actually introduce regression as pointed out in issue #29.

Needs to be investigated further.
