### PR TITLE
Switch to use `some ... in' again

### DIFF
--- a/policy/github/actions/workflows/name.rego
+++ b/policy/github/actions/workflows/name.rego
@@ -29,8 +29,7 @@ deny_no_name_in_workflow[msg] {
 deny_no_name_in_job[msg] {
 	f := concat("/", [data.conftest.file.dir, data.conftest.file.name])
 	utils.is_github_workflows(f)
-	some job
-	input.jobs[job]
+	some job, _ in input.jobs
 	not input.jobs[job].name
 
 	msg := sprintf("Job `%v` should have a `name` key", [job])
@@ -39,8 +38,8 @@ deny_no_name_in_job[msg] {
 deny_no_name_in_step[msg] {
 	f := concat("/", [data.conftest.file.dir, data.conftest.file.name])
 	utils.is_github_workflows(f)
-	some job, step
-	input.jobs[job].steps[step]
+	some job, _ in input.jobs
+	some step, _ in input.jobs[job].steps
 	not input.jobs[job].steps[step].name
 
 	msg := sprintf(

--- a/policy/terraform/aws/aws_iam_policy_attachment.rego
+++ b/policy/terraform/aws/aws_iam_policy_attachment.rego
@@ -17,8 +17,7 @@ package terraform.aws.aws_iam_policy_attachment
 import future.keywords.in
 
 deny_aws_iam_policy_attachment[msg] {
-	some resource
-	input.resource.aws_iam_policy_attachment[resource]
+	some resource, _ in input.resource.aws_iam_policy_attachment
 
 	msg := sprintf(
 		"`aws_iam_policy_attachment` `%v` creates exclusive attachment",

--- a/policy/venom/name.rego
+++ b/policy/venom/name.rego
@@ -25,16 +25,15 @@ deny_no_name[msg] {
 }
 
 deny_no_name_in_testcase[msg] {
-	some testcase
-	input.testcases[testcase]
+	some testcase, _ in input.testcases
 	not input.testcases[testcase].name
 
 	msg := sprintf("Test case `%v` should have a `name` key", [testcase])
 }
 
 deny_no_name_in_step[msg] {
-	some testcase, step
-	input.testcases[testcase].steps[step]
+	some testcase, _ in input.testcases
+	some step, _ in input.testcases[testcase].steps
 	not input.testcases[testcase].steps[step].name
 
 	msg := sprintf(


### PR DESCRIPTION
Switch to use `some ... in` again, this time hopefully correctly.

In commit 35314ce23f7676b95fae18f73f9577aff2f0da03 there were the problem that by using only a single argument with `in` operator, we actually unified with the actual object, not its key.

- Further checks were wrong because they assumed the key, not the object
- This made reporting when a violation happened more verbose (entire object was printed instead of just the interesting key)

Use the `in` operator with two arguments in order to get the key and preserve the behaviour that we had.

Closes issue #29.