### PR TITLE
Address constant-condition Regal violations

### DIFF
--- a/policy/github/actions/workflows/utils.rego
+++ b/policy/github/actions/workflows/utils.rego
@@ -28,11 +28,3 @@ is_github_workflows(s) if {
 is_github_workflows(s) if {
 	glob.match("**/.github/workflows/*.yaml", [], s)
 }
-
-# XXX: Silence the
-# XXX: `? - ... - github.actions.workflows.utils - no policies found'
-# XXX: warning because this package does not contain any policy
-# XXX: otherwise.
-deny if {
-	false
-}

--- a/policy/github/dependabot/utils.rego
+++ b/policy/github/dependabot/utils.rego
@@ -23,11 +23,3 @@ import future.keywords.if
 is_github_dependabot(s) if {
 	glob.match("**/.github/dependabot.yml", [], s)
 }
-
-# XXX: Silence the
-# XXX: `? - ... - github.dependabot.utils - no policies found'
-# XXX: warning because this package does not contain any policy
-# XXX: otherwise.
-deny if {
-	false
-}


### PR DESCRIPTION
Remove all the NOP policy that were add to silence 'no policies found' warning.

It seems that current conftest-0.45.0 (with opa-0.56.0) does not throw any warnings.
