### PR TITLE
Add initial Regal configuration

### DIFF
--- a/.regal/config.yaml
+++ b/.regal/config.yaml
@@ -1,0 +1,9 @@
+rules:
+  style:
+    line-length:
+      level: error
+      ignore:
+        files:
+          # Long URLs in related_resources.ref that could not be shortened
+          - "policy/github/dependabot/mandatory_toplevel_keys.rego"
+          - "policy/github/dependabot/utils.rego"


### PR DESCRIPTION
Ignore files that trigger line-length policy violation due long URLs in related_resources.ref. Unfortunately I do not think we can use inline comment to only ignore such line right now.
