### PR TITLE
Generate documentation for all packages

### DIFF
--- a/.github/workflows/conftest.yml
+++ b/.github/workflows/conftest.yml
@@ -8,6 +8,7 @@ name: Check and validate Conftest Rego policies
 
 env:
   CONFTEST_VERSION: "0.45.0"
+  OPA_VERSION: "0.56.0"
   REGAL_VERSION: "0.8.0"
 
 jobs:
@@ -21,6 +22,11 @@ jobs:
         run: |
           mkdir -p "${HOME}/.local/bin"
           curl -sL "https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz" | tar xzf - -C "${HOME}/.local/bin" conftest
+      - name: Install opa
+        run: |
+          mkdir -p "${HOME}/.local/bin"
+          curl -o "${HOME}/.local/bin/opa" -sL "https://github.com/open-policy-agent/opa/releases/download/v${OPA_VERSION}/opa_linux_amd64"
+          chmod +x "${HOME}/.local/bin/opa" 
       - name: Install regal
         run: |
           mkdir -p "${HOME}/.local/bin"
@@ -35,3 +41,7 @@ jobs:
       - name: Unit testing conftest policies
         run: |
           make test
+      - name: Ensure that all documentation is updated
+        run: |
+          make docs
+          git status --porcelain | awk '{ print } END { exit (NR > 0) }'

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,17 @@
 
 CONFTEST = conftest
 REGAL = regal
+REGEN_DOCS = ./scripts/regen-docs.sh
 
 all:
 
 check-fmt:
 	@echo "Checking Rego formatting style"
 	@$(CONFTEST) fmt --check .
+
+docs:
+	@echo "Regenerating documentation"
+	@$(REGEN_DOCS)
 
 fmt:
 	@echo "Formatting Rego files"

--- a/policy/github/actions/workflows/README.md
+++ b/policy/github/actions/workflows/README.md
@@ -1,0 +1,42 @@
+# `data.github.actions.workflows.name` - Check `name` keys for workflow, job and steps
+
+GitHub Actions workflows permit to have `name` keys for workflows, jobs and
+steps.
+
+The `name` field serves as a short description of workflow/job/step and it
+is used in several ways in the UI of GitHub Actions.
+
+Enforcing that is always present make the GitHub Actions workflow more
+readable and avoid machine-generated `name` that can be hard to follow.
+
+## References
+
+- [Workflow syntax for GitHub Actions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions)
+
+# `data.github.actions.workflows.setup_version` - Check that `*-version` in `setup-*` actions is a string
+
+The `*-version` parameters in GitHub Actions workflows `setup-*` should be
+a string in order to properly work with versions.
+
+By omitting string in YAML it can fallback to be parsed as a float and
+accidentally truncate any possible trailing `0`.
+
+For example, by using `go-version: 1.20` intended to require Go `1.20`
+it will be actually parsed as `go-version: 1.2` and Go `1.2` will
+be used instead!
+
+## References
+
+- [GitHub - actions/setup-go](https://github.com/actions/setup-go)
+- [GitHub - actions/setup-java](https://github.com/actions/setup-java)
+- [GitHub - actions/setup-node](https://github.com/actions/setup-node)
+- [GitHub - actions/setup-python](https://github.com/actions/setup-python)
+
+# `data.github.actions.workflows.utils` - Utility helpers for github.actions.workflows packages
+
+Utility helpers for github.actions.workflows packages providing common code
+for dealing with GitHub Actions workflows.
+
+## References
+
+- [Workflow syntax for GitHub Actions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions)

--- a/policy/github/dependabot/README.md
+++ b/policy/github/dependabot/README.md
@@ -1,0 +1,17 @@
+# `data.github.dependabot.mandatory_toplevel_keys` - Check mandatory top-level keys
+
+All dependabot.yml files should have `version` and `updates` top-level
+keys.
+
+## References
+
+- [Configuration options for the dependabot.yml file](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file)
+
+# `data.github.dependabot.utils` - Utility helpers for github.dependabot packages
+
+Utility helpers for github.dependabot packages providing common code
+for dealing with GitHub `dependabot.yml` file.
+
+## References
+
+- [Configuration options for the dependabot.yml file](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file)

--- a/policy/terraform/aws/README.md
+++ b/policy/terraform/aws/README.md
@@ -1,0 +1,14 @@
+# `data.terraform.aws.aws_iam_policy_attachment` - Prohibit use of `aws_iam_policy_attachment`
+
+`aws_iam_policy_attachment` creates an exclusive attachment of IAM
+policies. If the IAM policy is attached to any other user(s), role(s) and/or
+group(s) via another `aws_iam_policy_attachment` the original user(s),
+role(s) and/or group(s) will get the attached IAM policy revoked.
+
+`aws_iam_role_policy_attachment`, `aws_iam_user_policy_attachment` and
+`aws_iam_group_policy_attachment` can be always used instead and do not have
+any exclusive attachment.
+
+## References
+
+- [`aws_iam_policy_attachment` `hashicorp/aws` provider resource documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy_attachment)

--- a/policy/venom/README.md
+++ b/policy/venom/README.md
@@ -1,0 +1,26 @@
+# `data.venom.name` - Check `name` keys for test suite, test cases and steps
+
+Venom permit to have `name` keys for test suite, test cases and steps.
+
+The `name` field serves as a short description and is used in several ways
+in the report of Venom. For test cases it is used as an identifier to
+permit referencing test variables.
+
+Enforcing that is always present make the Venom tests more readable.
+
+## References
+
+- [Venom | Concepts](https://github.com/ovh/venom#concepts)
+
+# `data.venom.timeout` - Enforce `timeout` key for tests
+
+Test steps can hangs indefinitely if they do not define a `timeout`.
+
+Always define a `timeout` in all tests to avoid that.
+
+If for some reason this needs to be bypassed, explicitly set `timeout`
+to 0.
+
+## References
+
+- [CWE-400: Uncontrolled Resource Consumption](https://cwe.mitre.org/data/definitions/400.html)

--- a/scripts/regen-docs.sh
+++ b/scripts/regen-docs.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+#
+# Helper script to regenarate all documentation
+#
+# Should be executed from root directory where policy/ is present.
+#
+
+set -eu
+
+: ${REGEN_PACKAGE_DOCS:="./scripts/regen-package-docs.sh"}
+
+find . -name '*.rego' -exec dirname {} \; | sort -u | while read d; do
+	${REGEN_PACKAGE_DOCS} "${d}" > "${d}/README.md"
+done

--- a/scripts/regen-package-docs.sh
+++ b/scripts/regen-package-docs.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+
+#
+# Given a Rego policy as argument generate a README.md from its annotation.
+#
+# WARNING: no kind of validation is done! It is assumed that OPA metadata
+# annotations is also valid Markdown.
+#
+# Needs opa and jq.
+#
+
+set -eu
+
+if [ $# -le 0 ]; then
+	echo "usage: $0 <path> [<path> [...]]"
+	exit 1
+fi
+
+opa inspect --annotations --format json "$@" |
+jq -r '
+	[
+		.annotations[] |
+		select(.annotations.scope == "package") |
+		{
+			"path": ([.path[] | .value] | join(".")),
+			"title": .annotations.title,
+			"description": .annotations.description,
+			"references": ((
+				[
+					.annotations.related_resources[]? |
+					"- [\(.description)](\(.ref))"
+				] | join("\n")
+			) // "")
+		}
+	] |
+	[
+		.[] | [
+			"# `\(.path)` - \(.title)",
+			"",
+			"\(.description)",
+			(if (.references | length) > 0 then
+				"## References\n" +
+				"\n" +
+				"\(.references)"
+			else
+				empty
+			end)
+		] | join("\n")
+	] | join("\n\n")
+' |
+awk '
+# Eat all empty lines at the end of file
+#
+# XXX: It is unclear WTH jq adds them in case of no references.
+# XXX: This is a kludge to avoid them!
+
+# Bufferize all empty lines
+/^$/ {
+	empty_lines++
+	next
+}
+
+# Non-empty line
+{
+	# Print all possible empty lines non printed before
+	if (empty_lines > 0) {
+		for (i = 1; i <= empty_lines; i++) {
+			printf "\n"
+		}
+		empty_lines = 0
+	}
+
+	print
+}
+'


### PR DESCRIPTION
This PR adds scripts in order to automatically (re)generate package(s) documentation so that all packages are documented.

It also adjust the GitHub Actions workflow in order to check that documentation is updated.

Please see actual commit messages for further details.
