### PR TITLE
Enable strict mode for verify

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,4 +24,4 @@ lint:
 
 test:
 	@echo "Unit testing conftest rules"
-	@$(CONFTEST) verify --policy .
+	@$(CONFTEST) verify --strict --policy .


### PR DESCRIPTION
Strict mode help to spot several mistakes/deprecated features and will be probably enabled in OPA 1.0. Enable it for `test` target.

(It seems that we're ready for it without any adjustments, yay!)
