### PR TITLE
Update to OPA 0.57.0

### DIFF
--- a/.github/workflows/conftest.yml
+++ b/.github/workflows/conftest.yml
@@ -8,7 +8,7 @@ name: Check and validate Conftest Rego policies
 
 env:
   CONFTEST_VERSION: "0.46.0"
-  OPA_VERSION: "0.56.0"
+  OPA_VERSION: "0.57.0"
   REGAL_VERSION: "0.9.0"
 
 jobs:


### PR DESCRIPTION
Changes:
0.57.0
------
This release contains an updated Rego syntax to allow general
references in rule heads, and a mix of new features and bugfixes.
