### PR TITLE
Add entrypoint annotation to all packages

### DIFF
--- a/policy/github/actions/workflows/name.rego
+++ b/policy/github/actions/workflows/name.rego
@@ -12,6 +12,7 @@
 # related_resources:
 # - ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
 #   description: Workflow syntax for GitHub Actions
+# entrypoint: true
 package github.actions.workflows.name
 
 import future.keywords.in

--- a/policy/github/actions/workflows/setup_version.rego
+++ b/policy/github/actions/workflows/setup_version.rego
@@ -19,6 +19,7 @@
 #   description: GitHub - actions/setup-node
 # - ref: https://github.com/actions/setup-python
 #   description: GitHub - actions/setup-python
+# entrypoint: true
 package github.actions.workflows.setup_version
 
 import future.keywords.in

--- a/policy/github/actions/workflows/utils.rego
+++ b/policy/github/actions/workflows/utils.rego
@@ -6,6 +6,7 @@
 # related_resources:
 # - ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
 #   description: Workflow syntax for GitHub Actions
+# entrypoint: true
 package github.actions.workflows.utils
 
 import future.keywords.if

--- a/policy/github/dependabot/mandatory_toplevel_keys.rego
+++ b/policy/github/dependabot/mandatory_toplevel_keys.rego
@@ -6,6 +6,7 @@
 # related_resources:
 # - ref: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 #   description: Configuration options for the dependabot.yml file
+# entrypoint: true
 package github.dependabot.mandatory_toplevel_keys
 
 import future.keywords.in

--- a/policy/github/dependabot/utils.rego
+++ b/policy/github/dependabot/utils.rego
@@ -6,6 +6,7 @@
 # related_resources:
 # - ref: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 #   description: Configuration options for the dependabot.yml file
+# entrypoint: true
 package github.dependabot.utils
 
 import future.keywords.if

--- a/policy/terraform/aws/aws_iam_policy_attachment.rego
+++ b/policy/terraform/aws/aws_iam_policy_attachment.rego
@@ -12,6 +12,7 @@
 # related_resources:
 # - ref: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy_attachment
 #   description: "`aws_iam_policy_attachment` `hashicorp/aws` provider resource documentation"
+# entrypoint: true
 package terraform.aws.aws_iam_policy_attachment
 
 import future.keywords.in

--- a/policy/venom/name.rego
+++ b/policy/venom/name.rego
@@ -11,6 +11,7 @@
 # related_resources:
 # - ref: https://github.com/ovh/venom#concepts
 #   description: 'Venom | Concepts'
+# entrypoint: true
 package venom.name
 
 import future.keywords.in

--- a/policy/venom/timeout.rego
+++ b/policy/venom/timeout.rego
@@ -10,6 +10,7 @@
 # related_resources:
 # - ref: https://cwe.mitre.org/data/definitions/400.html
 #   description: 'CWE-400: Uncontrolled Resource Consumption'
+# entrypoint: true
 package venom.timeout
 
 import future.keywords.in


### PR DESCRIPTION
Rules and packages that should be used as entrypoints should be marked via the entrypoint annotation.

Noticed via new Regal 0.10.0 `no-defined-entrypoint` rule.

Mechanically done via:

```console
ag -l -G '.rego' 'METADATA' |
xargs ag -l '^package' |
xargs sed -i -e 's;^package;# entrypoint: true\npackage;'
```
