### PR TITLE
Switch to use `non-breakable-word-threshold`

### DIFF
--- a/.regal/config.yaml
+++ b/.regal/config.yaml
@@ -2,8 +2,4 @@ rules:
   style:
     line-length:
       level: error
-      ignore:
-        files:
-          # Long URLs in related_resources.ref that could not be shortened
-          - "policy/github/dependabot/mandatory_toplevel_keys.rego"
-          - "policy/github/dependabot/utils.rego"
+      non-breakable-word-threshold: 80


### PR DESCRIPTION
Instead of ignoring `line-length` with Regal 0.10.0 we can use `non-breakable-word-threshold`.

Now long URLs should be no longer problematic!
