### PR TITLE
Switch to StyraInc/setup-regal GitHub Actions

### DIFF
--- a/.github/workflows/conftest.yml
+++ b/.github/workflows/conftest.yml
@@ -9,7 +9,6 @@ name: Check and validate Conftest Rego policies
 env:
   CONFTEST_VERSION: "0.46.0"
   OPA_VERSION: "0.57.0"
-  REGAL_VERSION: "0.10.0"
 
 jobs:
   conftest:
@@ -27,11 +26,8 @@ jobs:
           mkdir -p "${HOME}/.local/bin"
           curl -o "${HOME}/.local/bin/opa" -sL "https://github.com/open-policy-agent/opa/releases/download/v${OPA_VERSION}/opa_linux_amd64"
           chmod +x "${HOME}/.local/bin/opa" 
-      - name: Install regal
-        run: |
-          mkdir -p "${HOME}/.local/bin"
-          curl -o "${HOME}/.local/bin/regal" -sL "https://github.com/StyraInc/regal/releases/download/v${REGAL_VERSION}/regal_Linux_x86_64"
-          chmod +x "${HOME}/.local/bin/regal" 
+      - name: Setup regal
+        uses: StyraInc/setup-regal@v0.1.0
       - name: Checking Rego formatting style
         run: |
           make check-fmt


### PR DESCRIPTION
setup-regal GitHub Actions was recently published. This avoid manually fetching regal binary every time.

By default the latest Regal version is also used that enforce to be up to date with current rules.

NFCI.
