### PR TITLE
Switch to open-policy-agent/setup-opa GitHub Actions

### DIFF
--- a/.github/workflows/conftest.yml
+++ b/.github/workflows/conftest.yml
@@ -8,7 +8,6 @@ name: Check and validate Conftest Rego policies
 
 env:
   CONFTEST_VERSION: "0.46.0"
-  OPA_VERSION: "0.57.0"
 
 jobs:
   conftest:
@@ -21,11 +20,8 @@ jobs:
         run: |
           mkdir -p "${HOME}/.local/bin"
           curl -sL "https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz" | tar xzf - -C "${HOME}/.local/bin" conftest
-      - name: Install opa
-        run: |
-          mkdir -p "${HOME}/.local/bin"
-          curl -o "${HOME}/.local/bin/opa" -sL "https://github.com/open-policy-agent/opa/releases/download/v${OPA_VERSION}/opa_linux_amd64"
-          chmod +x "${HOME}/.local/bin/opa" 
+      - name: Setup opa
+        uses: open-policy-agent/setup-opa@v2
       - name: Setup regal
         uses: StyraInc/setup-regal@v0.1.0
       - name: Checking Rego formatting style


### PR DESCRIPTION
Avoid to manually fetch and extract opa binary and delegate all of that to setup-opa GitHub Actions.

By default the latest OPA version is also used, this is fine and it enforces to keep the documentation/metadata updated.

NFCI.
