### PR TITLE
Avoid `-t` option in mktemp

### DIFF
--- a/scripts/regen-package-docs.sh
+++ b/scripts/regen-package-docs.sh
@@ -21,7 +21,7 @@ fi
 # XXX: because `cfg` depends on functions that are defined only in
 # XXX: conftest and not available in OPA.
 # XXX: Create a temporary bundle without tests to workaround that.
-tmpfile="$(mktemp -t conftest-package-docs)"
+tmpfile="$(mktemp)"
 opa build --bundle --ignore '*_test.rego' --output "${tmpfile}" "$@"
 opa inspect --annotations --format json "${tmpfile}" |
 jq -r '


### PR DESCRIPTION
The semantic of `-t` depends on the various mktemp implementations...  Avoid possibly workaround-ing/adjusting that and instead just use it without any arguments.
