### PR TITLE
Switch to new rego.v1 import

### DIFF
--- a/policy/github/actions/workflows/name.rego
+++ b/policy/github/actions/workflows/name.rego
@@ -15,9 +15,7 @@
 # entrypoint: true
 package github.actions.workflows.name
 
-import future.keywords.contains
-import future.keywords.if
-import future.keywords.in
+import rego.v1
 
 import data.github.actions.workflows.utils
 

--- a/policy/github/actions/workflows/name_test.rego
+++ b/policy/github/actions/workflows/name_test.rego
@@ -1,6 +1,6 @@
 package github.actions.workflows.name_test
 
-import future.keywords.if
+import rego.v1
 
 import data.github.actions.workflows.name
 

--- a/policy/github/actions/workflows/setup_version.rego
+++ b/policy/github/actions/workflows/setup_version.rego
@@ -22,9 +22,7 @@
 # entrypoint: true
 package github.actions.workflows.setup_version
 
-import future.keywords.contains
-import future.keywords.if
-import future.keywords.in
+import rego.v1
 
 import data.github.actions.workflows.utils
 

--- a/policy/github/actions/workflows/setup_version_test.rego
+++ b/policy/github/actions/workflows/setup_version_test.rego
@@ -1,6 +1,6 @@
 package github.actions.workflows.setup_version_test
 
-import future.keywords.if
+import rego.v1
 
 import data.github.actions.workflows.setup_version
 

--- a/policy/github/actions/workflows/utils.rego
+++ b/policy/github/actions/workflows/utils.rego
@@ -9,7 +9,7 @@
 # entrypoint: true
 package github.actions.workflows.utils
 
-import future.keywords.if
+import rego.v1
 
 # METADATA
 # title: Checks if a string matches GitHub Actions workflows path

--- a/policy/github/actions/workflows/utils_test.rego
+++ b/policy/github/actions/workflows/utils_test.rego
@@ -1,6 +1,6 @@
 package github.actions.workflows.utils_test
 
-import future.keywords.if
+import rego.v1
 
 import data.github.actions.workflows.utils
 

--- a/policy/github/dependabot/mandatory_toplevel_keys.rego
+++ b/policy/github/dependabot/mandatory_toplevel_keys.rego
@@ -9,9 +9,7 @@
 # entrypoint: true
 package github.dependabot.mandatory_toplevel_keys
 
-import future.keywords.contains
-import future.keywords.if
-import future.keywords.in
+import rego.v1
 
 import data.github.dependabot.utils
 

--- a/policy/github/dependabot/mandatory_toplevel_keys_test.rego
+++ b/policy/github/dependabot/mandatory_toplevel_keys_test.rego
@@ -1,6 +1,6 @@
 package github.dependabot.mandatory_toplevel_keys_test
 
-import future.keywords.if
+import rego.v1
 
 import data.github.dependabot.mandatory_toplevel_keys
 

--- a/policy/github/dependabot/utils.rego
+++ b/policy/github/dependabot/utils.rego
@@ -9,7 +9,7 @@
 # entrypoint: true
 package github.dependabot.utils
 
-import future.keywords.if
+import rego.v1
 
 # METADATA
 # title: Checks if a string matches GitHub `dependabot.yml` path

--- a/policy/github/dependabot/utils_test.rego
+++ b/policy/github/dependabot/utils_test.rego
@@ -1,6 +1,6 @@
 package github.dependabot.utils_test
 
-import future.keywords.if
+import rego.v1
 
 import data.github.dependabot.utils
 

--- a/policy/terraform/aws/aws_iam_policy_attachment.rego
+++ b/policy/terraform/aws/aws_iam_policy_attachment.rego
@@ -15,9 +15,7 @@
 # entrypoint: true
 package terraform.aws.aws_iam_policy_attachment
 
-import future.keywords.contains
-import future.keywords.if
-import future.keywords.in
+import rego.v1
 
 deny_aws_iam_policy_attachment contains msg if {
 	some resource, _ in input.resource.aws_iam_policy_attachment

--- a/policy/terraform/aws/aws_iam_policy_attachment_test.rego
+++ b/policy/terraform/aws/aws_iam_policy_attachment_test.rego
@@ -1,6 +1,6 @@
 package terraform.aws.aws_iam_policy_attachment_test
 
-import future.keywords.if
+import rego.v1
 
 import data.terraform.aws.aws_iam_policy_attachment
 

--- a/policy/venom/name.rego
+++ b/policy/venom/name.rego
@@ -14,9 +14,7 @@
 # entrypoint: true
 package venom.name
 
-import future.keywords.contains
-import future.keywords.if
-import future.keywords.in
+import rego.v1
 
 deny_no_name contains msg if {
 	# Check explicitly for input.testcases to avoid triggering for user

--- a/policy/venom/name_test.rego
+++ b/policy/venom/name_test.rego
@@ -1,6 +1,6 @@
 package venom.name_test
 
-import future.keywords.if
+import rego.v1
 
 import data.venom.name
 

--- a/policy/venom/timeout.rego
+++ b/policy/venom/timeout.rego
@@ -13,9 +13,7 @@
 # entrypoint: true
 package venom.timeout
 
-import future.keywords.contains
-import future.keywords.if
-import future.keywords.in
+import rego.v1
 
 deny_no_timeout contains msg if {
 	some testcase, step

--- a/policy/venom/timeout_test.rego
+++ b/policy/venom/timeout_test.rego
@@ -1,6 +1,6 @@
 package venom.timeout_test
 
-import future.keywords.if
+import rego.v1
 
 import data.venom.timeout
 


### PR DESCRIPTION
Instead of importing future keywords since OPA 0.59.0 it is suggested to directly `import rego.v1` instead of using `import future.keywords`.

Pointed out via regal's use-rego-v1 rule.

Mechanically done via:

```
opa fmt --rego-v1 --write .
```
