### PR TITLE
Add missing scope annotation

### DIFF
--- a/policy/github/actions/workflows/utils.rego
+++ b/policy/github/actions/workflows/utils.rego
@@ -22,6 +22,7 @@ import rego.v1
 # related_resources:
 # - ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
 #   description: Workflow syntax for GitHub Actions
+# scope: document
 is_github_workflows(s) if {
 	glob.match("**/.github/workflows/*.yml", [], s)
 }


### PR DESCRIPTION
The metadata is for all the `is_github_workflows` in the document, mark it accordingly.

Pointed out by Regal `ambiguous-scope` rule.
