### PR TITLE
Enable custom missing-metadata rule

### DIFF
--- a/.regal/config.yaml
+++ b/.regal/config.yaml
@@ -3,6 +3,12 @@ project:
     - policy
 
 rules:
+  custom:
+    missing-metadata:
+      level: error
+      ignore:
+        files:
+          - "*_test.rego"
   style:
     line-length:
       level: error

--- a/policy/github/actions/workflows/name/name.rego
+++ b/policy/github/actions/workflows/name/name.rego
@@ -19,6 +19,10 @@ import rego.v1
 
 import data.github.actions.workflows.utils
 
+# METADATA
+# description: |
+#  Deny workflow without name.
+# scope: rule
 deny_no_name_in_workflow contains msg if {
 	f := concat("/", [sprintf("%s", [data.conftest.file.dir]), sprintf("%s", [data.conftest.file.name])])
 	utils.is_github_workflows(f)
@@ -27,6 +31,10 @@ deny_no_name_in_workflow contains msg if {
 	msg := "Workflow should have a `name` key"
 }
 
+# METADATA
+# description: |
+#  Deny job without name.
+# scope: rule
 deny_no_name_in_job contains msg if {
 	f := concat("/", [sprintf("%s", [data.conftest.file.dir]), sprintf("%s", [data.conftest.file.name])])
 	utils.is_github_workflows(f)
@@ -36,6 +44,10 @@ deny_no_name_in_job contains msg if {
 	msg := sprintf("Job `%v` should have a `name` key", [job])
 }
 
+# METADATA
+# description: |
+#  Deny step without name.
+# scope: rule
 deny_no_name_in_step contains msg if {
 	f := concat("/", [sprintf("%s", [data.conftest.file.dir]), sprintf("%s", [data.conftest.file.name])])
 	utils.is_github_workflows(f)

--- a/policy/github/actions/workflows/setup_version/setup_version.rego
+++ b/policy/github/actions/workflows/setup_version/setup_version.rego
@@ -26,6 +26,10 @@ import rego.v1
 
 import data.github.actions.workflows.utils
 
+# METADATA
+# description: |
+#  Deny non-string go-version:.
+# scope: rule
 deny_setup_go_version contains msg if {
 	f := concat("/", [data.conftest.file.dir, data.conftest.file.name])
 	utils.is_github_workflows(f)
@@ -39,6 +43,10 @@ deny_setup_go_version contains msg if {
 	)
 }
 
+# METADATA
+# description: |
+#  Deny non-string java-version:.
+# scope: rule
 deny_setup_java_version contains msg if {
 	f := concat("/", [data.conftest.file.dir, data.conftest.file.name])
 	utils.is_github_workflows(f)
@@ -52,6 +60,10 @@ deny_setup_java_version contains msg if {
 	)
 }
 
+# METADATA
+# description: |
+#  Deny non-string node-version:.
+# scope: rule
 deny_setup_node_version contains msg if {
 	f := concat("/", [data.conftest.file.dir, data.conftest.file.name])
 	utils.is_github_workflows(f)
@@ -65,6 +77,10 @@ deny_setup_node_version contains msg if {
 	)
 }
 
+# METADATA
+# description: |
+#  Deny non-string python-version:.
+# scope: rule
 deny_setup_python_version contains msg if {
 	f := concat("/", [data.conftest.file.dir, data.conftest.file.name])
 	utils.is_github_workflows(f)

--- a/policy/github/dependabot/mandatory_toplevel_keys/mandatory_toplevel_keys.rego
+++ b/policy/github/dependabot/mandatory_toplevel_keys/mandatory_toplevel_keys.rego
@@ -13,6 +13,10 @@ import rego.v1
 
 import data.github.dependabot.utils
 
+# METADATA
+# description: |
+#  Deny dependabot without updates.
+# scope: rule
 deny_no_updates contains msg if {
 	f := concat("/", [data.conftest.file.dir, data.conftest.file.name])
 	utils.is_github_dependabot(f)
@@ -21,6 +25,10 @@ deny_no_updates contains msg if {
 	msg := "`dependabot.yml` should have an `updates` top-level key"
 }
 
+# METADATA
+# description: |
+#  Deny dependabot without version.
+# scope: rule
 deny_no_version contains msg if {
 	f := concat("/", [data.conftest.file.dir, data.conftest.file.name])
 	utils.is_github_dependabot(f)
@@ -29,6 +37,10 @@ deny_no_version contains msg if {
 	msg := "`dependabot.yml` should have `version` top-level key"
 }
 
+# METADATA
+# description: |
+#  Deny dependabot with invalid version.
+# scope: rule
 deny_incorrect_version contains msg if {
 	f := concat("/", [data.conftest.file.dir, data.conftest.file.name])
 	utils.is_github_dependabot(f)

--- a/policy/terraform/aws/aws_iam_policy_attachment/aws_iam_policy_attachment.rego
+++ b/policy/terraform/aws/aws_iam_policy_attachment/aws_iam_policy_attachment.rego
@@ -17,6 +17,10 @@ package terraform.aws.aws_iam_policy_attachment
 
 import rego.v1
 
+# METADATA
+# description: |
+#  Deny aws_iam_policy_attachment usage.
+# scope: rule
 deny_aws_iam_policy_attachment contains msg if {
 	some resource, _ in input.resource.aws_iam_policy_attachment
 

--- a/policy/venom/name/name.rego
+++ b/policy/venom/name/name.rego
@@ -16,6 +16,10 @@ package venom.name
 
 import rego.v1
 
+# METADATA
+# description: |
+#  Deny test suite without name.
+# scope: rule
 deny_no_name contains msg if {
 	# Check explicitly for input.testcases to avoid triggering for user
 	# defined executors
@@ -25,6 +29,10 @@ deny_no_name contains msg if {
 	msg := "Test suite should have a `name` key"
 }
 
+# METADATA
+# description: |
+#  Deny test case without name.
+# scope: rule
 deny_no_name_in_testcase contains msg if {
 	some testcase, _ in input.testcases
 	not input.testcases[testcase].name
@@ -32,6 +40,10 @@ deny_no_name_in_testcase contains msg if {
 	msg := sprintf("Test case `%v` should have a `name` key", [testcase])
 }
 
+# METADATA
+# description: |
+#  Deny step without name.
+# scope: rule
 deny_no_name_in_step contains msg if {
 	some testcase, _ in input.testcases
 	some step, _ in input.testcases[testcase].steps

--- a/policy/venom/timeout/timeout.rego
+++ b/policy/venom/timeout/timeout.rego
@@ -15,6 +15,10 @@ package venom.timeout
 
 import rego.v1
 
+# METADATA
+# description: |
+#  Deny step without timeout.
+# scope: rule
 deny_no_timeout contains msg if {
 	some testcase, step
 	input.testcases[testcase].steps[step]
@@ -26,6 +30,10 @@ deny_no_timeout contains msg if {
 	)
 }
 
+# METADATA
+# description: |
+#  Warn step with 0 timeout.
+# scope: rule
 warn_zero_timeout contains msg if {
 	some testcase, step
 	input.testcases[testcase].steps[step].timeout == 0


### PR DESCRIPTION
Document all rules and enforce missing-metadata rule on all Rego files except tests.

In that way we are forced to write documentation for each rule.
