### PR TITLE
Relax StyraInc/regal to just pick major version

### DIFF
--- a/.github/workflows/conftest.yml
+++ b/.github/workflows/conftest.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup opa
         uses: open-policy-agent/setup-opa@v2
       - name: Setup regal
-        uses: StyraInc/setup-regal@v1.0.0
+        uses: StyraInc/setup-regal@v1
       - name: Checking Rego formatting style
         run: |
           make check-fmt


### PR DESCRIPTION
Also according the documentation just requiring it via @v1 is fine.

This is also consistent with most other GitHub Actions.

NFC.
