### PR TITLE
Run CI at least once weekly

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -5,6 +5,8 @@ name: Check GitHub Actions workflows
     branches:
       - main
   pull_request:
+  schedule:
+    - cron: '12 3 * * 3'
 
 jobs:
   actionlint:

--- a/.github/workflows/conftest-self.yml
+++ b/.github/workflows/conftest-self.yml
@@ -5,6 +5,8 @@ name: Validate via personal conftest policies
     branches:
       - main
   pull_request:
+  schedule:
+    - cron: '12 3 * * 3'
 
 jobs:
   conftest:

--- a/.github/workflows/conftest.yml
+++ b/.github/workflows/conftest.yml
@@ -5,6 +5,8 @@ name: Check and validate Conftest Rego policies
     branches:
       - main
   pull_request:
+  schedule:
+    - cron: '12 3 * * 3'
 
 env:
   CONFTEST_VERSION: "0.56.0"

--- a/.github/workflows/mdformat.yml
+++ b/.github/workflows/mdformat.yml
@@ -5,6 +5,8 @@ name: Check Markdown formatting via mdformat
     branches:
       - main
   pull_request:
+  schedule:
+    - cron: '12 3 * * 3'
 
 jobs:
   mdformat:


### PR DESCRIPTION
According "Continuous integration" capability by DevOps Research and Assessment (DORA), quoting relevant part:

> You should run your build process successfully at least once a day.

From <https://dora.dev/capabilities/continuous-integration/>

Once a day for personal projects is probably too much so let limit ourselves to once a week for environmental reasons.

Time and day of the week are mostly random outside working hours in US/EU.
