### PR TITLE
Do not pull/write policies

### DIFF
--- a/.github/workflows/conftest-self.yml
+++ b/.github/workflows/conftest-self.yml
@@ -17,7 +17,5 @@ jobs:
         uses: actions/checkout@v4
       - name: Validate via personal conftest policies
         uses: docker://openpolicyagent/conftest:latest
-        env:
-          CONFTEST_POLICIES: git::https://github.com/iamleot/conftest-policies.git//policy/github
         with:
-          args: test --all-namespaces --update "${{ env.CONFTEST_POLICIES }}" .github/workflows
+          args: test --all-namespaces .github/workflows


### PR DESCRIPTION
Reuse policies available under policy instead of (re)fetching them via Git. Trying to overwrite policies fails since conftest-0.57.0.

Should fix #68.
