### PR TITLE
Ignore data files for unresolved-reference

### DIFF
--- a/.regal/config.yaml
+++ b/.regal/config.yaml
@@ -9,6 +9,10 @@ rules:
       ignore:
         files:
           - "*_test.rego"
+  imports:
+    unresolved-reference:
+      except-paths:
+        - data.conftest.file.*
   style:
     line-length:
       level: error


### PR DESCRIPTION
Add an exception for `data.conftest.file.*` that contains only data and should be ignored by `unresolved-reference`.

(If under data.conftest someday there will be other references we should change that to just `data.conftest.*`.)
