### PR TITLE
Revoke all unneeded permissions to GitHub Actions

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,4 +1,5 @@
 name: Check GitHub Actions workflows
+permissions: {}
 
 'on':
   push:

--- a/.github/workflows/conftest-self.yml
+++ b/.github/workflows/conftest-self.yml
@@ -1,4 +1,5 @@
 name: Validate via personal conftest policies
+permissions: {}
 
 'on':
   push:

--- a/.github/workflows/conftest.yml
+++ b/.github/workflows/conftest.yml
@@ -1,4 +1,5 @@
 name: Check and validate Conftest Rego policies
+permissions: {}
 
 'on':
   push:

--- a/.github/workflows/mdformat.yml
+++ b/.github/workflows/mdformat.yml
@@ -1,4 +1,5 @@
 name: Check Markdown formatting via mdformat
+permissions: {}
 
 'on':
   push:


### PR DESCRIPTION
Only "metadata" read permissions are actually needed and these are given by default also with `permissions: {}`.

`actions/checkout` says that `permissions.contents: read` is needed. However, for our use cases no contents operations are actually needed.

---

The permissions can be seen under each GitHub Actions workflow logs, under "Set up job", there is something like the following:

> GITHUB_TOKEN Permissions
>  Contents: read
>  Metadata: read
>  Packages: read

...or something:

> GITHUB_TOKEN Permissions
>   Actions: write
>   ArtifactMetadata: write
>   Attestations: write
>   Checks: write
>   Contents: write
>   Deployments: write
>   Discussions: write
>   Issues: write
>   Metadata: read
>   Models: read
>   Packages: write
>   Pages: write
>   PullRequests: write
>   RepositoryProjects: write
>   SecurityEvents: write
>   Statuses: write

And yeah, all these write-s are much more dangerous in case `GITHUB_TOKEN` gets leaked!

---

Please see <https://github.com/iamleot/rpi-flux/pull/190> for corresponding experiments too.
